### PR TITLE
Manage /etc/default/shorewall6 when installing shorewall6.

### DIFF
--- a/shorewall/etcdefault.sls
+++ b/shorewall/etcdefault.sls
@@ -8,3 +8,12 @@ shorewall_etcdefault:
     - watch_in:
       - service: shorewall_v4
 
+{%- if 6 in salt['pillar.get']('shorewall:ipv', [4]) %}
+shorewall6_etcdefault:
+  file.managed:
+    - name: {{ map.etcdefault6_file }}
+    - source: salt://shorewall/files/etcdefault.jinja
+    - template: jinja
+    - watch_in:
+      - service: shorewall_v6
+{%- endif %}

--- a/shorewall/map.jinja
+++ b/shorewall/map.jinja
@@ -10,6 +10,7 @@
     'macro_path': '/etc/shorewall',
     'config_files': ['zones', 'interfaces', 'policy', 'rules', 'masq', 'routestopped', 'params', 'tcinterfaces', 'tcpri', 'tcdevices', 'tcclasses', 'tcrules'],
     'etcdefault_file': '/etc/default/shorewall',
+    'etcdefault6_file': '/etc/default/shorewall6',
   },
   'RedHat': {
     'pkg': 'shorewall',


### PR DESCRIPTION
This creates the /etc/default/shorewall6 from the same template (and same pillar data) as /etc/default/shorewall.
