### PR TITLE
Interfaces template variable name typo fix

### DIFF
--- a/shorewall/files/interfaces.jinja
+++ b/shorewall/files/interfaces.jinja
@@ -21,7 +21,7 @@
 {%-   if zone_data.ipv is defined and zone_data.ipv != ipv %}{% continue %}{%endif %}
 {%-   for interface, interface_data in zone_data.get('interfaces', {}).iteritems() %}
 {#      skip if ip version does not match #}
-{%-     if interface_data.ipv is defined and interface_data_data.ipv != ipv %}{% continue %}{%endif %}
+{%-     if interface_data.ipv is defined and interface_data.ipv != ipv %}{% continue %}{%endif %}
 
 # {{ interface }}
 # {{ interface_data.comment if interface_data.comment is defined else '' }}


### PR DESCRIPTION
interfaces_data_data does not exist, interfaces_data, however, does and
is the right to use... Seems like a typo.
