### PR TITLE
Old version support

### DIFF
--- a/shorewall/files/etcdefault.jinja
+++ b/shorewall/files/etcdefault.jinja
@@ -3,7 +3,7 @@
 {%- set options = salt['pillar.get']('shorewall:etcdefault:options', '') %}
 {%- set startoptions = salt['pillar.get']('shorewall:etcdefault:startoptions', '') %}
 {%- set restartoptions = salt['pillar.get']('shorewall:etcdefault:restartoptions', '') %}
-{%- set initlog = salt['pillar.get']('shorewall:etcdefault:startup', '/dev/null') %}
+{%- set initlog = salt['pillar.get']('shorewall:etcdefault:initlog', '/dev/null') %}
 {%- set safestop = salt['pillar.get']('shorewall:etcdefault:safestop', 0) %}
 
 # prevent startup with default configuration

--- a/shorewall/files/etcdefault.jinja
+++ b/shorewall/files/etcdefault.jinja
@@ -3,7 +3,7 @@
 {%- set options = salt['pillar.get']('shorewall:etcdefault:options', '') %}
 {%- set startoptions = salt['pillar.get']('shorewall:etcdefault:startoptions', '') %}
 {%- set restartoptions = salt['pillar.get']('shorewall:etcdefault:restartoptions', '') %}
-{%- set initlog = salt['pillar.get']('shorewall:etcdefault:initlog', '/dev/null') %}
+{%- set initlog = salt['pillar.get']('shorewall:etcdefault:startup', '/dev/null') %}
 {%- set safestop = salt['pillar.get']('shorewall:etcdefault:safestop', 0) %}
 
 # prevent startup with default configuration

--- a/shorewall/files/rules.jinja
+++ b/shorewall/files/rules.jinja
@@ -15,12 +15,21 @@
 ######################################################################################################################################################################################################
 #ACTION         SOURCE          DEST            PROTO   DEST    SOURCE          ORIGINAL        RATE            USER/   MARK    CONNLIMIT       TIME            HEADERS         SWITCH          HELPER
 #                                                       PORT    PORT(S)         DEST            LIMIT           GROUP
+{%- if (salt['pkg.version']('shorewall')|string())[0:3]|float() >= 4.6 %}
 ?SECTION ALL
 ?SECTION ESTABLISHED
 ?SECTION RELATED
 ?SECTION INVALID
 ?SECTION UNTRACKED
 ?SECTION NEW
+{%- else %}
+SECTION ALL
+SECTION ESTABLISHED
+SECTION RELATED
+SECTION INVALID
+SECTION UNTRACKED
+SECTION NEW
+{%- endif %}
 
 
 {%- for rule in salt['pillar.get']('shorewall:rules', {}) %}

--- a/shorewall/files/rules.jinja
+++ b/shorewall/files/rules.jinja
@@ -15,7 +15,7 @@
 ######################################################################################################################################################################################################
 #ACTION         SOURCE          DEST            PROTO   DEST    SOURCE          ORIGINAL        RATE            USER/   MARK    CONNLIMIT       TIME            HEADERS         SWITCH          HELPER
 #                                                       PORT    PORT(S)         DEST            LIMIT           GROUP
-{%- if (salt['pkg.version']('shorewall')|string())[0:3]|float() >= 4.6 %}
+{%- if (salt['pkg.version'](pkg)|string())[0:3]|float() >= 4.6 %}
 ?SECTION ALL
 ?SECTION ESTABLISHED
 ?SECTION RELATED

--- a/shorewall/files/rules.jinja
+++ b/shorewall/files/rules.jinja
@@ -15,7 +15,7 @@
 ######################################################################################################################################################################################################
 #ACTION         SOURCE          DEST            PROTO   DEST    SOURCE          ORIGINAL        RATE            USER/   MARK    CONNLIMIT       TIME            HEADERS         SWITCH          HELPER
 #                                                       PORT    PORT(S)         DEST            LIMIT           GROUP
-{%- if (salt['pkg.version'](pkg)|string())[0:3]|float() >= 4.6 %}
+{%- if pkg_version|float() >= 4.6 %}
 ?SECTION ALL
 ?SECTION ESTABLISHED
 ?SECTION RELATED

--- a/shorewall/init.sls
+++ b/shorewall/init.sls
@@ -10,6 +10,7 @@
 {%- set name = 'shorewall_v{0}'.format(v) %}
 {%- set config_path = map['config_path_v{0}'.format(v)] %}
 {%- set service = map['service_v{0}'.format(v)] %}
+{%- set pkg_version = (salt['pkg.version'](pkg)|string())[0:3] %}
 
 {# Install required packages #}
 shorewall_v{{ v }}:
@@ -42,7 +43,8 @@ shorewall_v{{ v }}_config_{{ config }}:
     - watch_in:
       - service: {{ name }}
     - context:
-      ipv: {{ v }}
+        ipv: {{ v }}
+        pkg_version: {{ pkg_version }}
 
 {%-   endfor %}
 {%- endfor %}


### PR DESCRIPTION
This is fixing https://github.com/saltstack-formulas/shorewall-formula/pull/4

This is also fixing a bug in the usage of context: it is required to user 4 spaces in the indentation of a dictionarty declaration (like how it is the usage of default and contaxt).
