### PR TITLE
create macros from pillars

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -6,6 +6,12 @@ shorewall:
   macros:
     - macro.SaltMaster
 
+  macros_pillar:
+    macro.SaltMaster:    # You can enter as many rules as you want with the same syntax for the file rules.
+      - action: PARAM
+        proto: tcp
+        destport: 4505,4506
+
   zones:
     mgmt:
       ipv: 4                        # This controls if this item is used for ipv4 and/or ipv6 shorewall. Omit for both.

--- a/shorewall/files/macro_pillars.jinja
+++ b/shorewall/files/macro_pillars.jinja
@@ -1,0 +1,19 @@
+#
+# Shorewall version 4 - {{ macro }}
+#
+# /usr/share/shorewall/{{ macro }}
+#
+#
+###############################################################################
+#ACTION SOURCE  DEST    PROTO   DEST    SOURCE  RATE    USER/
+#               PORT(S) PORT(S) LIMIT   GROUP
+{%- set path = ['shorewall', 'macros_pillar', macro]|join(':') %}
+{%- for rule in salt['pillar.get'](path, {}) %}
+{%-   if rule is string %}
+{{ rule }}
+{%-   else %}
+# {{ rule.get('comment', '') }}
+{{ rule.get('action') }}  {{ rule.get('source', '-') }}  {{ rule.get('dest', '-') }}  {{ rule.get('proto', '-') }}  {{ rule.get('destport', '-') }}  {{ rule.get('sourceport', '-') }}  {{ rule.get('originaldest', '-') }}  {{ rule.get('ratelimit', '-') }}  {{ rule.get('usergroup', '-') }}  {{ rule.get('mark', '-') }}  {{ rule.get('connlimit', '-') }}  {{ rule.get('time', '-') }}  {{ rule.get('headers', '-') }}  {{ rule.get('switch', '') }}
+{%-   endif %} 
+{%- endfor %}
+#LAST LINE -- ADD YOUR ENTRIES BEFORE THIS ONE -- DO NOT REMOVE

--- a/shorewall/init.sls
+++ b/shorewall/init.sls
@@ -91,7 +91,7 @@ shorewall_enable_tc_simple_v6:
 
 {%- endif %}
 
-{# Install macro files #}
+{# Install macro from files #}
 {% for macro in salt['pillar.get']('shorewall:macros', {}) %}
 shorewall_config_macro_{{ loop.index }}:
   file.managed:
@@ -105,3 +105,21 @@ shorewall_config_macro_{{ loop.index }}:
     - watch_in:
       - service: shorewall_v4
 {% endfor %}
+{# Install macro from pillars #}
+{% for macro in salt['pillar.get']('shorewall:macros_pillar', {}) %}
+shorewall_config_macro_{{ loop.index }}:
+  file.managed:
+    - name: {{ map.macro_path }}/{{ macro }}
+    - source: salt://shorewall/files/macro_pillars.jinja
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: '0644'
+    - defaults:
+        macro: {{ macro }}
+    - require:
+      - pkg: shorewall_v4
+    - watch_in:
+      - service: shorewall_v4
+{% endfor %}
+


### PR DESCRIPTION
I added the functionality to create macro files from pillars and not just by copying them from the path /shorewall/files/macro.MyMacro of the formula.

I believe that this way it will be easier to use the shorewall formula to create custom macros: it's no more required to fork the formula just for adding some custom macros.

Hoping that you'll enjoy,
best regards.
