### PR TITLE
Wrap 0644 permission into quotes

### DIFF
--- a/shorewall/init.sls
+++ b/shorewall/init.sls
@@ -37,7 +37,7 @@ shorewall_v{{ v }}_config_{{ config }}:
     - template: jinja
     - user: root
     - group: root
-    - mode: 0644
+    - mode: '0644'
     - require:
       - pkg: {{ name }}
     - watch_in:
@@ -99,7 +99,7 @@ shorewall_config_macro_{{ loop.index }}:
     - source: salt://shorewall/files/{{ macro }}
     - user: root
     - group: root
-    - mode: 0644
+    - mode: '0644'
     - require:
       - pkg: shorewall_v4
     - watch_in:


### PR DESCRIPTION
Looking ant [YAML Idiosyncrasies](https://docs.saltstack.com/en/latest/topics/troubleshooting/yaml_idiosyncrasies.html#integers-are-parsed-as-integers) Salt documentation, 0644 will be interpreted as octal and  becomes 420. 

This solution is to wrap it in quotes to make it a string and avoid YAML interpretation.
