### PR TITLE
shorewall version not detected if shorewall is not already installed

### DIFF
--- a/shorewall/init.sls
+++ b/shorewall/init.sls
@@ -10,7 +10,12 @@
 {%- set name = 'shorewall_v{0}'.format(v) %}
 {%- set config_path = map['config_path_v{0}'.format(v)] %}
 {%- set service = map['service_v{0}'.format(v)] %}
-{%- set pkg_version = (salt['pkg.version'](pkg)|string())[0:3] %}
+{%- set installed_pkg_version = salt['pkg.version'](pkg)|string() %}
+{%- if installed_pkg_version %}
+{%-   set pkg_version = installed_pkg_version[0:3] %}
+{%- else %}
+{%-   set pkg_version = (salt['pkg.latest_version'](pkg)|string())[0:3] %}
+{%- endif %}
 
 {# Install required packages #}
 shorewall_v{{ v }}:


### PR DESCRIPTION
When shorewall package is not jet installed, the formula does not detect correctly the shorewall version that will be used. Because of this often incompatible files are provided.

Please see the proposed patch.

Thanks.