### PR TITLE
Dynamically generated params with mine

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -76,8 +76,18 @@ shorewall:
       ipv: 4
 
   params:
+    # you can specify a value
     - key: "NET_BCAST"
       value: "130.252.100.255"
+    # or a mine query to be executed
+    - key: "AUTHORIZED_SERVERS"
+      comment: Dynamic list of authorized servers
+      mine:
+        target: I@UseServer
+        function: main_ipaddr
+        expr_form: compound
+      # mine query needs a default value if no results
+      default: 127.0.0.1
 
   tcinterfaces:
     - name: ppp0

--- a/shorewall/files/params.jinja
+++ b/shorewall/files/params.jinja
@@ -31,7 +31,25 @@
 {%-   if params.ipv is defined and params.ipv != ipv %}{% continue %}{%endif %}
 
 # {{ params.get('comment', '') }}
+{%- if params.get('value') %}
 {{ params.get('key') }}={{ params.get('value') }}
+
+{%- elif params.get('mine') -%}
+
+{%- set mine_target = params.get('mine').get('target') -%}
+{%- set mine_function = params.get('mine').get('function') -%}
+{%- set mine_expr_form = params.get('mine').get('expr_form') -%}
+{%- set default = params.get('default') -%}
+
+{%- set mine_result = salt['mine.get'](mine_target, mine_function, mine_expr_form).values() %}
+{{ params.get('key') }}=
+{%- for result in mine_result -%}
+{{ result[0] }}{%- if not loop.last -%}{{','}}{%- endif -%}
+{%- else -%}
+{{ default }}
+{%- endfor -%}
+{%- endif -%}
+
 {%- endfor %}
 
 #LAST LINE -- DO NOT REMOVE

--- a/shorewall/files/params.jinja
+++ b/shorewall/files/params.jinja
@@ -26,6 +26,25 @@
 #
 ###############################################################################
 
+{# Renders a list (or list of lists) of IP addresses as Shorewall param format #}
+{%- macro render_list(list) -%}
+{%- set ip_list = [] -%}
+  {%- if list is not iterable -%}
+    {%- do ip_list.append(list) -%}
+  {%- else -%}
+    {%- for item in list -%}
+      {%- if item is not iterable -%}
+        {%- do ip_list.append(item) -%}
+      {%- else -%}
+        {%- for i in item -%}
+          {%- do ip_list.append(i) -%}
+        {%- endfor -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+{{ ip_list|join(',') }}
+{%- endmacro -%}
+
 {%- for params in salt['pillar.get']('shorewall:params', {}) %}
 {# skip if ip version does not match #}
 {%-   if params.ipv is defined and params.ipv != ipv %}{% continue %}{%endif %}
@@ -42,14 +61,16 @@
 {%- set default = params.get('default') -%}
 
 {%- set mine_result = salt['mine.get'](mine_target, mine_function, mine_expr_form).values() %}
-{{ params.get('key') }}=
-{%- for result in mine_result -%}
-{{ result[0] }}{%- if not loop.last -%}{{','}}{%- endif -%}
+
+{{ params.get('key') }}=
+{%- if mine_result -%}
+{{ render_list(mine_result) }}
 {%- else -%}
 {{ default }}
-{%- endfor -%}
+{%- endif -%}
 {%- endif -%}
 
 {%- endfor %}
 
 #LAST LINE -- DO NOT REMOVE
+


### PR DESCRIPTION
Hello,

this MR propose a solution to be able to generate Shorewall params with a dynamic query to Salt Mine #12.
Using pillar, you can specify which salt mine query you want, and also a default value, if this query returns no results.

The mine query can return a list of IP addresses, a list of lists of IPs, or a combination of those two formats and it'll be managed by the code.