### PR TITLE
Add custom configuration for shorewall.conf based on pillar

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -2,6 +2,10 @@ shorewall:
   ipv: # omit means 4 only. This controls wether shorewall or shorewall and shorewall6 is installed.
     - 4 # ipv4 support
     - 6 # ipv6 support. Cant' be used without ipv4!
+
+  config: # only work for ipv4
+    - key: "DOCKER"
+      value: "Yes"
   
   macros:
     - macro.SaltMaster

--- a/shorewall/init.sls
+++ b/shorewall/init.sls
@@ -105,3 +105,18 @@ shorewall_config_macro_{{ loop.index }}:
     - watch_in:
       - service: shorewall_v4
 {% endfor %}
+
+{# Replace key=value in shorewall.conf #}
+{%- if salt['pillar.get']('shorewall:config', False) %}
+{% for config in salt['pillar.get']('shorewall:config', {}) %}
+
+shorewall_config_custom_v4{{ loop.index }}:
+  file.replace:
+    - name: {{ map.config_path_v4 }}/shorewall.conf
+    - pattern: "{{ config.get('key') }}=.*"
+    - repl: "{{ config.get('key') }}={{ config.get('value') }}"
+    - watch_in:
+      - service: shorewall_v4
+
+{%- endfor %}
+{%- endif %}


### PR DESCRIPTION
It let the user add custom configuration directly in the pillar.

Example: enable docker, ip forwarding...